### PR TITLE
Use type="text/tailwindcss" to add custom CSS

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -322,7 +322,7 @@ module.exports = {
             let cssContent = fs.readFileSync(currentDirectory + '/assets/css/main.css', 'utf8');
             // We also want to replace the tailwindcss @tailwind commands:
             cssContent = cssContent.replace('@tailwind base;', '').replace('@tailwind components;', '').replace('@tailwind utilities;', '');
-            tailwindReplacement += `<style>${cssContent}</style>`;
+            tailwindReplacement += `<style type="text/tailwindcss">${cssContent}</style>`;
         }
         content = content.replace('{tailwindcss}', tailwindReplacement);
         


### PR DESCRIPTION
Use type="text/tailwindcss" to add custom CSS that supports all of Tailwind's CSS features.
https://tailwindcss.com/docs/installation/play-cdn

This allow the use of @​apply (and other custom tailwind functions) for main.css when within dev mode.

![Try Tailwind CSS using the Play CDN - Tailwind CSS — 2024-02-20 at 14 14 10@2x](https://github.com/thedevdojo/static/assets/1743221/88b09e13-b8cb-44d6-9419-5d2e68ffaa53)
