### PR TITLE
Add list pagination functionality 

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -555,7 +555,16 @@ module.exports = {
                 const orderBy = attributes.orderBy.split(',').map(item => item.trim());
                 const valueA = a[orderBy[0]];
                 const valueB = b[orderBy[0]];
-                let direction = 'asc';
+                //let direction = 'asc';
+                // Check if the orderBy array has more than one element
+                if (orderBy.length > 1) {
+                    // If there is more than one element, assume the second element specifies the sort direction
+                    // Convert the direction to lower case and trim any whitespace
+                    direction = orderBy[1].toLowerCase().trim();
+                }else{
+                    // Check if orderSort is 'desc' and set direction to 'desc' if true, otherwise set to 'asc' as default
+                    direction = attributes.orderSort == 'desc' ? 'desc' : 'asc'
+                }
         
                 if (orderBy.length > 1) {
                     direction = orderBy[1].toLowerCase().trim();


### PR DESCRIPTION
Hi, I have added pagination functionality, as shown in the image.

![image](https://github.com/user-attachments/assets/e2617f47-50f9-44fc-83a1-f969c693eb3d)

Using the Aira template as an example, when adding pagination to the list on the `/post` page of Aira:

1. Add pagination information to `static.json`

   ```json
   {
       "paginationList" : [
           {
               "route": "/posts",
               "pageSize": 2,
               "iteratorKey":"posts-loop"
           }
       ]
   }


 + `route`: Specifies which route page enables the pagination feature.
 + `pageSize`: The number of items displayed per page.
 + `iteratorKey`: Specifies which `<ForEach>` to paginate.

2. Add `iteratorKey` to the `<ForEach>` element

   ```
   <ForEach content="post" as="post" count="{count}" iteratorKey="posts-loop" >
   ```

   Now, the posts page only displays 2 items.

3. Use paginator to implement page switching.

   Add a paginator structure inside `<ForEach>`. This structure must contain two `<a>` tags and use "prev" and "next" to specify the switching direction.

   ```
   <ForEach content="post" as="post" count="{count}" iteratorKey="posts-loop"> 
       <div class="relative border border-transparent border-dashed cursor-pointer p-7 group rounded-2xl" onClick="window.location='{post.link}'">
           xxxx
       </div>
       <paginator>
           <div class="w-full flex justify-between">
               <a prev>
                   Prev
               </a>
               <a next>
                   Next
               </a>
           </div>
       </paginator>
   </ForEach>
   ```


   
![image](https://github.com/user-attachments/assets/72968ba7-9f29-4a66-b78e-fb62130d5aa0)
![image](https://github.com/user-attachments/assets/869dea0f-bfa5-48a2-b6d7-7cf9b2eb941d)
![image](https://github.com/user-attachments/assets/628f4aa0-03f5-4e5d-b61e-1a3f6844c2f2)



Here is how it works:

+ During the dev phase, the parser will match the data that needs pagination and perform slicing.

+ During the build phase, the builder will generate multiple subpages under the directory of the page.
  + when accessing `/posts/pgn/X`, it will load the data for page X. The paginator uses `href` for page navigation.

![image](https://github.com/user-attachments/assets/a0f4ce51-d48e-4656-b157-8941e39be3be)
![image](https://github.com/user-attachments/assets/e0ad4949-dd11-46d5-b655-e504dbdd9ae1)

Although I modified some methods in the parser.js, this does not affect the current project. 

All function calls remain the same as before.