### PR TITLE
Fix: could not determine executable to run

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -50,7 +50,7 @@ module.exports = {
         }
     },
     buildTailwindCSS(buildDir = './_site'){
-        exec("npx tailwindcss@latest -i ./assets/css/main.css -o " + buildDir + "/assets/css/main.css --minify", (err, stdout, stderr) => {
+        exec("npx tailwindcss -i ./assets/css/main.css -o " + buildDir + "/assets/css/main.css --minify", (err, stdout, stderr) => {
             if (err) {
             console.error("Error compling tailwindcss:");
             console.error(err);


### PR DESCRIPTION
Fixing:

```
static build
Successfully built your new static website 🤘
Error compling tailwindcss:
Error: Command failed: npx tailwindcss@latest -i ./assets/css/main.css -o /Users/user/www/_site/assets/css/main.css --minify
npm ERR! could not determine executable to run

npm ERR! A complete log of this run can be found in: /Users/user/.npm/_logs/2025-01-26T09_02_06_060Z-debug-0.log

    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at Socket.<anonymous> (node:internal/child_process:450:11)
    at Socket.emit (node:events:517:28)
    at Pipe.<anonymous> (node:net:350:12) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'npx tailwindcss@latest -i ./assets/css/main.css -o /Users/user/www/_site/assets/css/main.css --minify'
}
```